### PR TITLE
Configure & create topics

### DIFF
--- a/src/MinimalKafka/Extension/KafkaConsumerBuilderMetadataExtensions.cs
+++ b/src/MinimalKafka/Extension/KafkaConsumerBuilderMetadataExtensions.cs
@@ -2,17 +2,10 @@
 using Microsoft.Extensions.DependencyInjection;
 using MinimalKafka.Builders;
 using MinimalKafka.Metadata;
-using TopicMetadata = MinimalKafka.Metadata.TopicMetadata;
 
 namespace MinimalKafka.Extension;
 public static class KafkaConsumerBuilderMetadataExtensions
 {
-    private static readonly Func<Type, string> DefaultNamingConvention = type => type
-        .FQN()
-        .Replace('<', '-')
-        .Replace('<', '-')
-        .ToLowerInvariant();
-    
     public static TBuilder WithKeyDeserializer<TBuilder>(this TBuilder builder, Func<IKafkaConsumerBuilder, object> serializer)
         where TBuilder : IKafkaConventionBuilder
     {
@@ -70,32 +63,5 @@ public static class KafkaConsumerBuilderMetadataExtensions
             (candidateType.IsGenericType && candidateType.GetGenericTypeDefinition() == genericType ||
              candidateType.GetInterfaces().ToList().Exists(i => i.IsGenericType && i.GetGenericTypeDefinition() == genericType) ||
              candidateType.BaseType != null && candidateType.BaseType.IsTheGenericType(genericType));
-    }
-
-    public static TBuilder WithDefaultTopicOptions<TBuilder>(this TBuilder builder)
-        where TBuilder : IKafkaConventionBuilder
-    {
-        builder.WithSingle(new TopicMetadata(
-            DefaultNamingConvention,
-            null));
-        return builder;
-    }
-
-    public static TBuilder WithTopicOptions<TBuilder, TMessage>(this TBuilder builder, Func<Type, string>? namingConvention, TimeSpan? retentionPeriod)
-        where TBuilder : IKafkaConventionBuilder
-    {
-        builder.WithSingle(new TopicMetadata<TMessage>(
-            namingConvention ?? DefaultNamingConvention,
-            retentionPeriod));
-        return builder;
-    }
-
-    public static TBuilder WithTopicOptions<TBuilder, TMessage>(this TBuilder builder, string topicName, TimeSpan? retentionPeriod)
-        where TBuilder : IKafkaConventionBuilder
-    {
-        builder.WithSingle(new TopicMetadata<TMessage>(
-            _ => topicName,
-            retentionPeriod));
-        return builder;
     }
 }

--- a/src/MinimalKafka/Extension/KafkaConsumerBuilderMetadataExtensions.cs
+++ b/src/MinimalKafka/Extension/KafkaConsumerBuilderMetadataExtensions.cs
@@ -2,10 +2,17 @@
 using Microsoft.Extensions.DependencyInjection;
 using MinimalKafka.Builders;
 using MinimalKafka.Metadata;
+using TopicMetadata = MinimalKafka.Metadata.TopicMetadata;
 
 namespace MinimalKafka.Extension;
 public static class KafkaConsumerBuilderMetadataExtensions
 {
+    private static readonly Func<Type, string> DefaultNamingConvention = type => type
+        .FQN()
+        .Replace('<', '-')
+        .Replace('<', '-')
+        .ToLowerInvariant();
+    
     public static TBuilder WithKeyDeserializer<TBuilder>(this TBuilder builder, Func<IKafkaConsumerBuilder, object> serializer)
         where TBuilder : IKafkaConventionBuilder
     {
@@ -63,5 +70,32 @@ public static class KafkaConsumerBuilderMetadataExtensions
             (candidateType.IsGenericType && candidateType.GetGenericTypeDefinition() == genericType ||
              candidateType.GetInterfaces().ToList().Exists(i => i.IsGenericType && i.GetGenericTypeDefinition() == genericType) ||
              candidateType.BaseType != null && candidateType.BaseType.IsTheGenericType(genericType));
+    }
+
+    public static TBuilder WithDefaultTopicOptions<TBuilder>(this TBuilder builder)
+        where TBuilder : IKafkaConventionBuilder
+    {
+        builder.WithSingle(new TopicMetadata(
+            DefaultNamingConvention,
+            null));
+        return builder;
+    }
+
+    public static TBuilder WithTopicOptions<TBuilder, TMessage>(this TBuilder builder, Func<Type, string>? namingConvention, TimeSpan? retentionPeriod)
+        where TBuilder : IKafkaConventionBuilder
+    {
+        builder.WithSingle(new TopicMetadata<TMessage>(
+            namingConvention ?? DefaultNamingConvention,
+            retentionPeriod));
+        return builder;
+    }
+
+    public static TBuilder WithTopicOptions<TBuilder, TMessage>(this TBuilder builder, string topicName, TimeSpan? retentionPeriod)
+        where TBuilder : IKafkaConventionBuilder
+    {
+        builder.WithSingle(new TopicMetadata<TMessage>(
+            _ => topicName,
+            retentionPeriod));
+        return builder;
     }
 }

--- a/src/MinimalKafka/Extension/TypeExtensions.cs
+++ b/src/MinimalKafka/Extension/TypeExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System.Text;
+
+namespace MinimalKafka.Extension;
+
+public static class TypeExtensions
+{
+    public static string FQN(this Type type)
+    {
+        if (type == null) throw new ArgumentNullException(nameof(type));
+        
+        var sb = new StringBuilder();
+        
+        if (type.IsNested)
+        {
+            sb.Append(type.DeclaringType!.FQN());
+            sb.Append('.');
+        }
+        else
+        {
+            if (!string.IsNullOrEmpty(type.Namespace))
+            {
+                sb.Append(type.Namespace);
+                sb.Append('.');
+            }
+        }
+
+        sb.Append(type.Name);
+        
+        if (type.IsGenericType)
+        {
+            var genericArguments = type.GetGenericArguments();
+            var genericTypeName = type.Name.Substring(0, type.Name.IndexOf('`'));
+            sb.Append(genericTypeName);
+            sb.Append('<');
+            for (int i = 0; i < genericArguments.Length; i++)
+            {
+                if (i > 0) sb.Append(", ");
+                sb.Append(genericArguments[i].FQN());
+            }
+            sb.Append('>');
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/MinimalKafka/IMinimalProducer.cs
+++ b/src/MinimalKafka/IMinimalProducer.cs
@@ -1,0 +1,37 @@
+﻿using Confluent.Kafka;
+
+namespace MinimalKafka;
+
+public interface IMinimalProducer<TKey, TValue>
+{
+    /// <summary>
+    ///     Asynchronously send a single message to a
+    ///     Kafka topic. The partition the message is
+    ///     sent to is determined by the partitioner
+    ///     defined using the 'partitioner' configuration
+    ///     property.
+    /// </summary>
+    /// <param name="message">The message to produce.</param>
+    /// <param name="cancellationToken">
+    ///     A cancellation token to observe whilst waiting
+    ///     the returned task to complete.
+    /// </param>
+    /// <returns>
+    ///     A Task which will complete with a delivery
+    ///     report corresponding to the produce request,
+    ///     or an exception if an error occured.
+    /// </returns>
+    /// <exception cref="T:Confluent.Kafka.ProduceException`2">
+    ///     Thrown in response to any produce request
+    ///     that was unsuccessful for any reason
+    ///     (excluding user application logic errors).
+    ///     The Error property of the exception provides
+    ///     more detailed information.
+    /// </exception>
+    /// <exception cref="T:System.ArgumentException">
+    ///     Thrown in response to invalid argument values.
+    /// </exception>
+    Task<DeliveryResult<TKey, TValue>> ProduceAsync(
+        Message<TKey, TValue> message,
+        CancellationToken cancellationToken = default);
+}

--- a/src/MinimalKafka/KafkaExtensions.cs
+++ b/src/MinimalKafka/KafkaExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using MinimalKafka.Builders;
 using MinimalKafka.Extension;
+using MinimalKafka.Metadata;
 using MinimalKafka.Serializers;
 using MinimalKafka.Stream;
 using System.Text.Json;
@@ -48,11 +49,17 @@ public static class KafkaExtensions
 
         configBuilder.WithKeyDeserializer(typeof(JsonTextSerializer<>));
         configBuilder.WithValueDeserializer(typeof(JsonTextSerializer<>));
+        configBuilder.WithDefaultTopicOptions();
+        configBuilder.WithTopicOptions<ClientIdMetadataAttribute>();
 
         config(configBuilder);
 
         services.TryAddSingleton(new JsonSerializerOptions(JsonSerializerDefaults.Web));
         services.AddTransient(typeof(JsonTextSerializer<>));
+
+        services.AddSingleton<IAdminClient>(provider
+            => new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers })
+                .Build());
 
         services.AddSingleton<IKafkaBuilder>(s =>
         {

--- a/src/MinimalKafka/Metadata/ITopicMetadata.cs
+++ b/src/MinimalKafka/Metadata/ITopicMetadata.cs
@@ -1,0 +1,30 @@
+﻿#pragma warning disable S2326
+
+using MinimalKafka.Helpers;
+
+namespace MinimalKafka.Metadata;
+
+public interface ITopicMetadata
+{
+    Func<Type, string> NamingConvention { get; }
+    
+    TimeSpan? RetentionPeriod { get; }
+}
+
+public interface ITopicMetadata<T> : ITopicMetadata
+{
+}
+
+public class TopicMetadata(Func<Type, string> namingConvention, TimeSpan? retentionPeriod) : ITopicMetadata
+{
+    public Func<Type, string> NamingConvention { get; } = namingConvention;
+
+    public TimeSpan? RetentionPeriod { get; } = retentionPeriod;
+
+    /// <inheritdoc/>
+    public override string ToString()
+        => DebuggerHelpers.GetDebugText(nameof(TopicMetadata), NamingConvention);
+}
+
+public class TopicMetadata<T>(Func<Type, string> namingConvention, TimeSpan? retentionPeriod) :
+    TopicMetadata(namingConvention, retentionPeriod), ITopicMetadata<T>;


### PR DESCRIPTION
This change allows topics to be configured like so:
```csharp
config
    .WithTopicOptions<FirstMessage>(retentionPeriod: TimeSpan.FromDays(31))
    .WithTopicOptions<SecondMessage>(topicName: "second.message")
    .WithTopicOptions<ThirdMessage>(namingConvention: type => type.Name);
```

When the producer is created (before sending the first message) it is checked if a topic exists, and if not it will be created using the configured settings.