### PR TITLE
Set default ClientId and GroupId

### DIFF
--- a/src/MinimalKafka/KafkaExtensions.cs
+++ b/src/MinimalKafka/KafkaExtensions.cs
@@ -6,6 +6,7 @@ using MinimalKafka.Builders;
 using MinimalKafka.Extension;
 using MinimalKafka.Serializers;
 using MinimalKafka.Stream;
+using System.Reflection;
 using System.Text.Json;
 
 namespace MinimalKafka;
@@ -47,6 +48,8 @@ public static class KafkaExtensions
         var conventions = new List<Action<IKafkaBuilder>>();
         var configBuilder = new AddKafkaBuilder(services, conventions);
 
+        configBuilder.WithClientId(AppDomain.CurrentDomain.FriendlyName);
+        configBuilder.WithGroupId(AppDomain.CurrentDomain.FriendlyName);
         configBuilder.WithKeyDeserializer(typeof(JsonTextSerializer<>));
         configBuilder.WithValueDeserializer(typeof(JsonTextSerializer<>));
         configBuilder.WithTopicFormatter(topic => topic);

--- a/test/MinimalKafka.Tests/RegistrationTests.cs
+++ b/test/MinimalKafka.Tests/RegistrationTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using MinimalKafka.Builders;
+using MinimalKafka.Metadata;
 using MinimalKafka.Serializers;
 using MinimalKafka.Stream;
 using System.Diagnostics;
@@ -96,5 +97,26 @@ public class ServiceCollectionTests
 
         // Assert
         kafkaBuilder.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddMinimalKafa_Should_Set_ClientId_And_GroupId_To_Default()
+    {
+        var services = new ServiceCollection();
+
+        static void config(IAddKafkaBuilder builder) =>
+            builder.WithStreamStore(typeof(InMemoryStore<,>));
+
+        // Act
+        services.AddMinimalKafka(config);
+        var serviceProvider = services.BuildServiceProvider();
+        var kafkaBuilder = serviceProvider.GetRequiredService<IKafkaBuilder>();
+
+        // Assert
+        kafkaBuilder.MetaData
+            .Should()
+            .ContainSingle(x => x is IClientIdMetadata)
+            .And
+            .ContainSingle(x => x is IGroupIdMetadata);
     }
 }

--- a/test/MinimalKafka.Tests/RegistrationTests.cs
+++ b/test/MinimalKafka.Tests/RegistrationTests.cs
@@ -100,7 +100,7 @@ public class ServiceCollectionTests
     }
 
     [Fact]
-    public void AddMinimalKafa_Should_Set_ClientId_And_GroupId_To_Default()
+    public void AddMinimalKafka_Should_Set_ClientId_And_GroupId_To_Default()
     {
         var services = new ServiceCollection();
 
@@ -118,5 +118,14 @@ public class ServiceCollectionTests
             .ContainSingle(x => x is IClientIdMetadata)
             .And
             .ContainSingle(x => x is IGroupIdMetadata);
+
+        // Verify the actual values
+        var clientId = kafkaBuilder.MetaData
+            .OfType<IClientIdMetadata>().Single().ClientId;
+        var groupId = kafkaBuilder.MetaData
+            .OfType<IGroupIdMetadata>().Single().GroupId;
+
+        clientId.Should().Be(AppDomain.CurrentDomain.FriendlyName);
+        groupId.Should().Be(AppDomain.CurrentDomain.FriendlyName);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Kafka client ID and group ID are now automatically set to the application's name by default.
- **Tests**
  - Added a unit test to verify the default assignment of Kafka client ID and group ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->