### PR TITLE
Allow to set Consumer Handlers

### DIFF
--- a/examples/Examples/Program.cs
+++ b/examples/Examples/Program.cs
@@ -13,6 +13,9 @@ builder.Services.AddMinimalKafka(config =>
            .WithConfiguration(builder.Configuration.GetSection("Kafka"))
            .WithGroupId(Guid.NewGuid().ToString())
            .WithOffsetReset(AutoOffsetReset.Earliest)
+           .WithPartitionHandler((_, p) => {
+               return p.Select(tp => new TopicPartitionOffset(tp, Offset.Beginning));
+           })
            .WithJsonSerializers()
            .WithInMemoryStore();
  });

--- a/src/MinimalKafka/Extension/KafkaConsumerConfigMetadataExtensions.cs
+++ b/src/MinimalKafka/Extension/KafkaConsumerConfigMetadataExtensions.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Configuration;
 using MinimalKafka.Builders;
 using MinimalKafka.Metadata;
+using System.Reflection.Emit;
 
 namespace MinimalKafka.Extension;
 public static class KafkaConsumerConfigMetadataExtensions
@@ -59,6 +60,65 @@ public static class KafkaConsumerConfigMetadataExtensions
         where TBuilder : IKafkaConventionBuilder
     {
         builder.WithSingle(new TopicFormatterMetadataAttribute(clientIdFormatter));
+        return builder;
+    }
+
+    public static TBuilder WithPartitionHandler<TBuilder>(this TBuilder builder, Func<object, List<TopicPartition>, IEnumerable<TopicPartitionOffset>> handler)
+        where TBuilder : IKafkaConventionBuilder
+    {
+
+        builder.Add(b =>
+        {
+            if (!b.MetaData.OfType<ConsumerHandlerMetadata>().Any())
+            {
+                b.MetaData.Add(new ConsumerHandlerMetadata());
+            }
+
+            foreach (var item in b.MetaData.OfType<ConsumerHandlerMetadata>())
+            {
+                item.PartitionsAssignedHandler = handler;
+            }
+        });
+
+        return builder;
+    }
+    public static TBuilder WithErrorHandler<TBuilder>(this TBuilder builder, Action<object, Error> handler)
+        where TBuilder : IKafkaConventionBuilder
+    {
+
+        builder.Add(b =>
+        {
+            if (!b.MetaData.OfType<ConsumerHandlerMetadata>().Any())
+            {
+                b.MetaData.Add(new ConsumerHandlerMetadata());
+            }
+
+            foreach (var item in b.MetaData.OfType<ConsumerHandlerMetadata>())
+            {
+                item.ErrorHandler = handler;
+            }
+        });
+
+        return builder;
+    }
+
+    public static TBuilder WithStatisticsHandler<TBuilder>(this TBuilder builder, Action<object, string> handler)
+        where TBuilder : IKafkaConventionBuilder
+    {
+
+        builder.Add(b =>
+        {
+            if (!b.MetaData.OfType<ConsumerHandlerMetadata>().Any())
+            {
+                b.MetaData.Add(new ConsumerHandlerMetadata());
+            }
+
+            foreach (var item in b.MetaData.OfType<ConsumerHandlerMetadata>())
+            {
+                item.StatisticsHandler = handler;
+            }
+        });
+
         return builder;
     }
 

--- a/src/MinimalKafka/KafkaConsumerBuilder.cs
+++ b/src/MinimalKafka/KafkaConsumerBuilder.cs
@@ -58,7 +58,20 @@ internal class KafkaConsumerBuilder<TKey, TValue> : IKafkaConsumerBuilder
     public IConsumer<TKey, TValue> Build()
     {
         SetDeserializers(_consumerBuilder);
+        SetPartitionsAssignedHandler(_consumerBuilder);
         return _consumerBuilder.Build();
+    }
+
+    private void SetPartitionsAssignedHandler(ConsumerBuilder<TKey, TValue> consumerBuilder)
+    {
+        if(GetMetaData<IConsumerHandlerMetadata>(out var handlers))
+        {
+            if (handlers.PartitionsAssignedHandler is not null) consumerBuilder.SetPartitionsAssignedHandler(handlers.PartitionsAssignedHandler);
+            if (handlers.StatisticsHandler is not null) consumerBuilder.SetStatisticsHandler(handlers.StatisticsHandler);
+            if (handlers.ErrorHandler is not null) consumerBuilder.SetErrorHandler(handlers.ErrorHandler);
+         }
+
+        
     }
 
     private void SetDeserializers(ConsumerBuilder<TKey, TValue> builder)

--- a/src/MinimalKafka/KafkaExtensions.cs
+++ b/src/MinimalKafka/KafkaExtensions.cs
@@ -7,6 +7,7 @@ using MinimalKafka.Extension;
 using MinimalKafka.Serializers;
 using MinimalKafka.Stream;
 using System.Reflection;
+using System.Reflection.Emit;
 using System.Text.Json;
 
 namespace MinimalKafka;
@@ -114,6 +115,7 @@ public static class KafkaExtensions
 
         return builder;
     }
+
     private static IKafkaDataSource GetOrAddTopicDataSource(this IKafkaBuilder builder)
     {
         builder.DataSource ??= new KafkaDataSource(builder.ServiceProvider);

--- a/src/MinimalKafka/Metadata/IConsumerHandlerMetadata.cs
+++ b/src/MinimalKafka/Metadata/IConsumerHandlerMetadata.cs
@@ -1,0 +1,18 @@
+﻿using Confluent.Kafka;
+
+namespace MinimalKafka.Metadata;
+
+public interface IConsumerHandlerMetadata
+{
+    Func<object, List<TopicPartition>, IEnumerable<TopicPartitionOffset>>? PartitionsAssignedHandler { get; set; }
+
+    Action<object, string>? StatisticsHandler { get; set;}
+    Action<object, Error>? ErrorHandler { get;  set; }
+}
+
+internal class ConsumerHandlerMetadata : IConsumerHandlerMetadata
+{
+    public Func<object, List<TopicPartition>, IEnumerable<TopicPartitionOffset>>? PartitionsAssignedHandler { get; set; }
+    public Action<object, string>? StatisticsHandler { get; set; }
+    public Action<object, Error>? ErrorHandler { get; set; }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring custom handlers for partition assignment, error handling, and statistics reporting in Kafka consumers.
  - Users can now explicitly set the offset for assigned partitions to the beginning in minimal Kafka setups.

- **Improvements**
  - Enhanced Kafka consumer configuration flexibility with new extension methods for handler customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->