### PR TITLE
Fixed bug with producer logic

### DIFF
--- a/examples/Examples/Join/JoinExample.cs
+++ b/examples/Examples/Join/JoinExample.cs
@@ -23,12 +23,12 @@ public static class JoinExample
                 var store = c.GetTopicStore("aanvragers");
 
                 var eersteAanvrager = await store.FindByKey<string, Aanvrager>(uitgangspunt.EersteAanvragerId);
-                var tweedeAamvrager = await store.FindByKey<string, Aanvrager>(uitgangspunt.TweedeAanvragerId);
+                var tweedeAanvrager = await store.FindByKey<string, Aanvrager>(uitgangspunt.TweedeAanvragerId);
 
                 await c.ProduceAsync("uitgangspunten-met-aanvragers", uitgangspunt.Id, uitgangspunt with
                 {
                     EersteAanvrager = eersteAanvrager,
-                    TweedeAanvrager = tweedeAamvrager
+                    TweedeAanvrager = tweedeAanvrager
                 });
             });
     }

--- a/examples/Examples/Join/JoinExample.cs
+++ b/examples/Examples/Join/JoinExample.cs
@@ -1,0 +1,35 @@
+﻿using MinimalKafka;
+using MinimalKafka.Stream;
+namespace Examples.Join;
+
+public record Aanvrager(string BcNummer);
+public record Uitgangspunt(string Id, string EersteAanvragerId, string TweedeAanvragerId, Aanvrager? EersteAanvrager, Aanvrager? TweedeAanvrager);
+
+public static class JoinExample
+{
+
+    public static void MapJoinExample(this IApplicationBuilder builder)
+    {
+        builder.MapStream<string, Aanvrager>("aanvragers")
+            .Join<string, Uitgangspunt>("uitgangspunten")
+            .On((aanvrager, uitgangspunt) =>
+                uitgangspunt.EersteAanvragerId == aanvrager.BcNummer ||
+                uitgangspunt.TweedeAanvragerId == aanvrager.BcNummer)
+            .Into(async (c, result) =>
+            {
+
+                var (aanvrager, uitgangspunt) = result;
+
+                var store = c.GetTopicStore("aanvragers");
+
+                var eersteAanvrager = await store.FindByKey<string, Aanvrager>(uitgangspunt.EersteAanvragerId);
+                var tweedeAamvrager = await store.FindByKey<string, Aanvrager>(uitgangspunt.TweedeAanvragerId);
+
+                await c.ProduceAsync("uitgangspunten-met-aanvragers", uitgangspunt.Id, uitgangspunt with
+                {
+                    EersteAanvrager = eersteAanvrager,
+                    TweedeAanvrager = tweedeAamvrager
+                });
+            });
+    }
+}

--- a/examples/Examples/Program.cs
+++ b/examples/Examples/Program.cs
@@ -1,9 +1,8 @@
 using Confluent.Kafka;
-using Examples;
 using Examples.Aggregate;
+using Examples.Join;
 using MinimalKafka;
 using MinimalKafka.Aggregates;
-using MinimalKafka.Stream;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -28,7 +27,8 @@ builder.Services.AddMinimalKafka(config =>
 var app = builder.Build();
 
 
-app.MapAggregate<Test, Guid, TestCommands>("tests");
+app.MapJoinExample();
+//app.MapAggregate<Test, Guid, TestCommands>("tests");
 
 
 //app.MapTopic("my-topic", ([FromKey] string key, [FromValue] string value) =>

--- a/src/MinimalKafka/KafkaExtensions.cs
+++ b/src/MinimalKafka/KafkaExtensions.cs
@@ -6,7 +6,6 @@ using MinimalKafka.Builders;
 using MinimalKafka.Internals;
 using MinimalKafka.Metadata;
 using MinimalKafka.Serializers;
-using System.Text.Json;
 
 namespace MinimalKafka;
 
@@ -40,16 +39,6 @@ public static class KafkaExtensions
             var b = new KafkaBuilder(s);
             conventions.ForEach(x => x(b));
             return b;
-        });
-
-        services.AddSingleton(sp =>
-        {
-            var builder = sp.GetRequiredService<IKafkaBuilder>();
-            var config = builder.MetaData.OfType<IConfigMetadata>().First();
-            return new ProducerBuilder<byte[], byte[]>(config.ProducerConfig.AsEnumerable())
-                .SetKeySerializer(Confluent.Kafka.Serializers.ByteArray)
-                .SetValueSerializer(Confluent.Kafka.Serializers.ByteArray)
-                .Build();
         });
 
         services.AddTransient(typeof(IKafkaSerializer<>), typeof(KafkaSerializerProxy<>));


### PR DESCRIPTION
Introduces a `MapJoinExample` that demonstrates how to perform a join operation between two Kafka streams.

This example reads from "aanvragers" and "uitgangspunten" topics, joins them based on `EersteAanvragerId` or `TweedeAanvragerId`, and produces the joined result to the "uitgangspunten-met-aanvragers" topic.

The Kafka producer is now created and disposed within the `ProduceAsync` method to avoid potential issues with shared resources and to ensure proper cleanup after each use.  The producer configuration is also now retrieved directly from the KafkaContext.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an example demonstrating a stream join operation that enriches Kafka topic data by joining applicant information.

* **Bug Fixes**
  * Improved error handling and logging for Kafka producer operations.

* **Chores**
  * Updated dependency injection setup by removing the singleton Kafka producer registration.
  * Cleaned up unused using directives in example code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->