### PR TITLE
Corrects version string extraction

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -33,7 +33,7 @@ jobs:
           arrTag=(${GITHUB_REF//\// })
           VERSION="${arrTag[2]}"
           echo Version: $VERSION
-          VERSION="${VERSION//v}"
+          VERSION="${VERSION##v}"
           echo Clean Version: $VERSION
           dotnet pack -v normal --no-restore -p:PackageVersion=$VERSION --configuration Release --output packages
    


### PR DESCRIPTION
Refines version string extraction in the build workflow to correctly remove the leading "v" character.

This ensures accurate versioning for package publishing.