### PR TITLE
Simplifies Kafka store retrieval by topic name

### DIFF
--- a/examples/KafkaAdventure/Features/Movement/MovementFeature.cs
+++ b/examples/KafkaAdventure/Features/Movement/MovementFeature.cs
@@ -15,7 +15,7 @@ public static class MovementFeature
             .Join<string, Location>("game-player-position").OnKey()
             .Into(async (c, k, v) =>
             {
-                if (v.Item1 is null || c.ConsumerKey.TopicName == "game-player-position")
+                if (v.Item1 is null || c.TopicName == "game-player-position")
                 {
                     return;
                 }

--- a/src/MinimalKafka.Aggregates/AggregateExtensions.cs
+++ b/src/MinimalKafka.Aggregates/AggregateExtensions.cs
@@ -67,7 +67,7 @@ public static class AggregateExtensions
                 var (cmd, state) = join;
 
                 // Ignore null commands or recursive processing of state topic
-                if (cmd is null || c.ConsumerKey.TopicName == topicName)
+                if (cmd is null || c.TopicName == topicName)
                 {
                     return;
                 }

--- a/src/MinimalKafka.RocksDB/RocksDBStreamStoreFactory.cs
+++ b/src/MinimalKafka.RocksDB/RocksDBStreamStoreFactory.cs
@@ -52,14 +52,12 @@ internal sealed class RocksDBStreamStoreFactory : IDisposable, IKafkaStoreFactor
     }
 
     private readonly object _lock = new();
-    public IKafkaStore GetStore(KafkaConsumerKey consumerKey)
+    public IKafkaStore GetStore(string topicName)
     {
 
         lock (_lock)
         {
-            var key = $"{consumerKey.TopicName}_{consumerKey.GetHashCode()}";
-
-            var cfHandle = _columnFamilies.GetOrAdd(key, key =>
+            var cfHandle = _columnFamilies.GetOrAdd(topicName, key =>
             {
                 // Only create if truly absent
                 return _db.CreateColumnFamily(new ColumnFamilyOptions(), key);

--- a/src/MinimalKafka/IKafkaStore.cs
+++ b/src/MinimalKafka/IKafkaStore.cs
@@ -43,8 +43,8 @@ public interface IKafkaStoreFactory
     /// <summary>
     /// 
     /// </summary>
-    /// <param name="consumerKey"></param>
+    /// <param name="topicName"></param>
     /// <returns></returns>
-    public IKafkaStore GetStore(KafkaConsumerKey consumerKey);
+    public IKafkaStore GetStore(string topicName);
 }
     

--- a/src/MinimalKafka/Internals/KafkaConsumer.cs
+++ b/src/MinimalKafka/Internals/KafkaConsumer.cs
@@ -57,7 +57,7 @@ internal class KafkaConsumer(
                 logger.RecordsConsumed(config.Key.GroupId, config.Key.ClientId, _recordsConsumed, result.Topic);
             }
 
-            var context = KafkaContext.Create(config, result.Message, scope.ServiceProvider);
+            var context = KafkaContext.Create(config.Key.TopicName, config.Metadata, result.Message, scope.ServiceProvider);
 
             var store = context.GetTopicStore();
 

--- a/src/MinimalKafka/Internals/KafkaContextProducer.cs
+++ b/src/MinimalKafka/Internals/KafkaContextProducer.cs
@@ -40,8 +40,7 @@ internal class KafkaContextProducer(
 
     public async Task ProduceAsync<TKey, TValue>(string topic, TKey key, TValue value, Dictionary<string, string>? header = null)
     {
-        var config = KafkaConsumerConfig.Create(KafkaConsumerKey.Random(Guid.NewGuid().ToString()), [], []);
-        var context = KafkaContext.Create(config, new() { Key = [], Value = [] }, serviceProvider);
+        var context = KafkaContext.Create(topic, [], new() { Key = [], Value = [] }, serviceProvider);
         await context.ProduceAsync(topic, key, value, header);
         await ProduceAsync(context, CancellationToken.None);
     }

--- a/src/MinimalKafka/Internals/KafkaInMemoryStoreFactory.cs
+++ b/src/MinimalKafka/Internals/KafkaInMemoryStoreFactory.cs
@@ -1,21 +1,22 @@
 ﻿using Microsoft.Extensions.Hosting;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace MinimalKafka.Internals;
 
 internal class KafkaInMemoryStoreFactory(IServiceProvider serviceProvider) : BackgroundService, IKafkaStoreFactory
 {
-    private readonly ConcurrentDictionary<KafkaConsumerKey, KafkaInMemoryStore> _stores = [];
+    private readonly ConcurrentDictionary<string, KafkaInMemoryStore> _stores = [];
     private readonly object _lock = new();
 
-    public IKafkaStore GetStore(KafkaConsumerKey consumerKey)
+    public IKafkaStore GetStore(string topicName)
     {
         lock (_lock)
         {
-            if (!_stores.TryGetValue(consumerKey, out KafkaInMemoryStore? store))
+            if (!_stores.TryGetValue(topicName, out KafkaInMemoryStore? store))
             {
                 store = new KafkaInMemoryStore(serviceProvider);
-                _stores.TryAdd(consumerKey, store);
+                _stores.TryAdd(topicName, store);
 
             }
             return store;

--- a/src/MinimalKafka/KafkaContext.cs
+++ b/src/MinimalKafka/KafkaContext.cs
@@ -14,10 +14,10 @@ public class KafkaContext
 {
     private readonly Message<byte[], byte[]> _message;
 
-    private KafkaContext(KafkaConsumerConfig config, Message<byte[], byte[]> message, IServiceProvider requestServices)
+    private KafkaContext(string topic, IReadOnlyList<object> metadata, Message<byte[], byte[]> message, IServiceProvider requestServices)
     {
-        ConsumerKey = config.Key; 
-        Metadata = config.Metadata;
+        TopicName = topic; 
+        Metadata = metadata;
         RequestServices = requestServices;
         _message = message;
     }
@@ -26,7 +26,7 @@ public class KafkaContext
     /// <summary>
     /// The Unique ConsumerKey
     /// </summary>
-    public KafkaConsumerKey ConsumerKey { get; }
+    public string TopicName { get; }
 
     /// <summary>
     /// Thhe service provider.
@@ -53,8 +53,8 @@ public class KafkaContext
     public IReadOnlyDictionary<string, string> Headers => _message.Headers
         .ToDictionary(x => x.Key, y => Encoding.UTF8.GetString(y.GetValueBytes()));
 
-    internal static KafkaContext Create(KafkaConsumerConfig config, Message<byte[], byte[]> message, IServiceProvider serviceProvider)
-        => new(config, message, serviceProvider);
+    internal static KafkaContext Create(string topic, IReadOnlyList<object> metadata, Message<byte[], byte[]> message, IServiceProvider serviceProvider)
+        => new(topic, metadata, message, serviceProvider);
 
     internal void Produce(KafkaMessage message)
     {

--- a/src/MinimalKafka/KafkaContextExtenions.cs
+++ b/src/MinimalKafka/KafkaContextExtenions.cs
@@ -17,10 +17,7 @@ public static class KafkaContextExtenions
     public static IKafkaStore GetTopicStore(this KafkaContext context, string topicName)
     {
         return context.GetStoreFactory()
-            .GetStore(context.ConsumerKey with
-        {
-            TopicName = topicName
-        });
+            .GetStore(topicName);
     }
 
     /// <summary>
@@ -31,7 +28,7 @@ public static class KafkaContextExtenions
     public static IKafkaStore GetTopicStore(this KafkaContext context)
     {
         return context.GetStoreFactory()
-            .GetStore(context.ConsumerKey);
+            .GetStore(context.TopicName);
     }
 
     private static IKafkaStoreFactory GetStoreFactory(this KafkaContext context)

--- a/test/MinimalKafka.RocksDB.Tests/StreamStore_Tests.cs
+++ b/test/MinimalKafka.RocksDB.Tests/StreamStore_Tests.cs
@@ -24,7 +24,7 @@ public class StreamStore_Tests
         });
         var provider = services.BuildServiceProvider();
         var factory = provider.GetRequiredService<IKafkaStoreFactory>();
-        var streamStore = factory.GetStore(KafkaConsumerKey.Random("test"));
+        var streamStore = factory.GetStore("test");
         var key = Encoding.UTF8.GetBytes("key");
         var value = Encoding.UTF8.GetBytes("value");
 

--- a/test/MinimalKafka.Tests/DelegateFactoryTests.cs
+++ b/test/MinimalKafka.Tests/DelegateFactoryTests.cs
@@ -92,8 +92,7 @@ public class KafkaDelegateFactoryTests
 
         // Act
         var result = KafkaDelegateFactory.Create(handler, options);
-        var config = KafkaConsumerConfig.Create(KafkaConsumerKey.Random("topic"), [], []);
-        var context = KafkaContext.Create(config, new Message<byte[], byte[]>(), serviceProvider);
+        var context = KafkaContext.Create("topic", [], new Message<byte[], byte[]>(), serviceProvider);
 
         await result.Delegate.Invoke(context);
 
@@ -181,8 +180,7 @@ public class KafkaDelegateFactoryTests
             }
         };
 
-        var config = KafkaConsumerConfig.Create(KafkaConsumerKey.Random("topic"), [], []);
-        var context = KafkaContext.Create(config, new Message<byte[], byte[]>(), serviceProvider);
+        var context = KafkaContext.Create("topic", [], new Message<byte[], byte[]>(), serviceProvider);
 
         try
         {

--- a/test/MinimalKafka.Tests/KafkaContextTests.cs
+++ b/test/MinimalKafka.Tests/KafkaContextTests.cs
@@ -16,9 +16,7 @@ public class KafkaContextTests
         var serviceProvider = Substitute.For<IServiceProvider>();
 
         // Act
-        var config = KafkaConsumerConfig.Create(KafkaConsumerKey.Random("topic"), [], []);
-        var context = KafkaContext.Create(
-            config, 
+        var context = KafkaContext.Create("topic", [],
             new()
             {
                 Key = key,


### PR DESCRIPTION
Refactors Kafka store retrieval to use topic name as the key, instead of KafkaConsumerKey. This change simplifies the logic and improves performance, especially for RocksDB implementation. It also removes the need to pass the entire KafkaConsumerKey when retrieving a store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified store retrieval and context creation by using topic names as strings instead of consumer key objects throughout the application.
  * Updated method and constructor signatures to accept topic names directly, reducing dependency on configuration objects.
  * Adjusted internal logic across multiple components to align with the new approach for topic identification.

* **Tests**
  * Updated tests to use the new topic-based context and store creation methods, streamlining test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->