### PR TITLE
Default to JSON serialization and NullLogger

### DIFF
--- a/src/MinimalKafka/KafkaExtensions.cs
+++ b/src/MinimalKafka/KafkaExtensions.cs
@@ -1,6 +1,9 @@
 ﻿using Confluent.Kafka;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using MinimalKafka.Builders;
 using MinimalKafka.Internals;
 using MinimalKafka.Serializers;
@@ -30,8 +33,11 @@ public static class KafkaExtensions
         configBuilder.WithReportInterval(5);
         configBuilder.WithTopicFormatter(topic => topic);
         configBuilder.WithInMemoryStore();
+        configBuilder.WithJsonSerializers();
 
         config?.Invoke(configBuilder);
+
+        services.TryAddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
 
         services.AddSingleton<IKafkaBuilder>(s =>
         {

--- a/test/MinimalKafka.Tests/DelegateFactoryTests.cs
+++ b/test/MinimalKafka.Tests/DelegateFactoryTests.cs
@@ -1,6 +1,7 @@
 ﻿using Confluent.Kafka;
 using Microsoft.Extensions.DependencyInjection;
 using MinimalKafka.Builders;
+using MinimalKafka.Serializers;
 using System.Text;
 using System.Text.Json;
 
@@ -144,7 +145,8 @@ public class KafkaDelegateFactoryTests
     {
         var services = new ServiceCollection();
         services.AddSingleton(JsonSerializerOptions.Default);
-        //services.AddTransient(typeof(JsonTextSerializer<>));
+        services.AddSingleton<ISerializerFactory, SystemTextJsonSerializerFactory>();
+        services.AddTransient(typeof(IKafkaSerializer<>), typeof(KafkaSerializerProxy<>));
 
         // Arrange
         var serviceProvider = services.BuildServiceProvider();
@@ -172,17 +174,14 @@ public class KafkaDelegateFactoryTests
         var key = Encoding.UTF8.GetBytes("\"testKey\"");
         var value = Encoding.UTF8.GetBytes("\"testValue\"");
         var headers = new Headers();
-        var consumeResult = new ConsumeResult<byte[], byte[]>
+        var message = new Message<byte[], byte[]>
         {
-            Message = new Message<byte[], byte[]>
-            {
-                Key = key,
-                Value = value,
-                Headers = headers
-            }
+            Key = key,
+            Value = value,
+            Headers = headers
         };
 
-        var context = KafkaContext.Create(KafkaConsumerKey.Random("topic"), [], new Message<byte[], byte[]>(), serviceProvider);
+        var context = KafkaContext.Create(KafkaConsumerKey.Random("topic"), [], message, serviceProvider);
 
         await result.Delegate.Invoke(context);
     }

--- a/test/MinimalKafka.Tests/KafkaProcessTests.cs
+++ b/test/MinimalKafka.Tests/KafkaProcessTests.cs
@@ -31,8 +31,6 @@ public class KafkaProcessTests
     {
         var services = new ServiceCollection();
 
-        services.AddLogging();
-
         services.AddMinimalKafka(x => x.WithClientId("test-client"));
 
         _serviceProvider = services.BuildServiceProvider();


### PR DESCRIPTION
This simplifies initial setup by automatically registering JSON serializers for Kafka messages. It also improves robustness by ensuring a `NullLogger` is available when no explicit logging provider is configured, preventing potential dependency resolution issues.
