### PR TITLE
Rename FindByIdAsync to FindByKeyAsync for clarity

### DIFF
--- a/src/MinimalKafka.RocksDB/RocksDBStreamStore.cs
+++ b/src/MinimalKafka.RocksDB/RocksDBStreamStore.cs
@@ -13,7 +13,7 @@ internal class RocksDBStreamStore(IServiceProvider serviceProvider, RocksDb db, 
         return ValueTask.FromResult(value.ToArray());
     }
 
-    public ValueTask<byte[]?> FindByIdAsync(ReadOnlySpan<byte> key)
+    public ValueTask<byte[]?> FindByKeyAsync(ReadOnlySpan<byte> key)
     {
         var result = db.Get(key, cfHandle);
         return ValueTask.FromResult<byte[]?>(result);

--- a/src/MinimalKafka/IKafkaStore.cs
+++ b/src/MinimalKafka/IKafkaStore.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace MinimalKafka;
+﻿namespace MinimalKafka;
 
 /// <summary>
 /// 
@@ -25,14 +23,14 @@ public interface IKafkaStore
     /// </summary>
     /// <param name="key"></param>
     /// <returns></returns>
-    ValueTask<byte[]?> FindByIdAsync(ReadOnlySpan<byte> key);
+    ValueTask<byte[]?> FindByKeyAsync(ReadOnlySpan<byte> key);
 
     /// <summary>
     /// 
     /// </summary>
     /// <returns></returns>
-    IAsyncEnumerable<byte[]> GetItems();   
-    
+    IAsyncEnumerable<byte[]> GetItems();
+
 }
 
 /// <summary>
@@ -47,4 +45,3 @@ public interface IKafkaStoreFactory
     /// <returns></returns>
     public IKafkaStore GetStore(string topicName);
 }
-    

--- a/src/MinimalKafka/Internals/KafkaInMemoryStoreFactory.cs
+++ b/src/MinimalKafka/Internals/KafkaInMemoryStoreFactory.cs
@@ -62,7 +62,7 @@ internal class KafkaInMemoryStore(IServiceProvider serviceProvider, TimeProvider
         _store.CleanUp();
     }
 
-    public ValueTask<byte[]?> FindByIdAsync(ReadOnlySpan<byte> key)
+    public ValueTask<byte[]?> FindByKeyAsync(ReadOnlySpan<byte> key)
     {
         return _store.FindByIdAsync(key.ToArray());
     }

--- a/src/MinimalKafka/Stream/KafkaStoreExtensions.cs
+++ b/src/MinimalKafka/Stream/KafkaStoreExtensions.cs
@@ -27,7 +27,7 @@ public static class KafkaStoreExtensions
 
         var keyVal = keySerializer.Serialize(key);
 
-        var value = await store.FindByIdAsync(keyVal);
+        var value = await store.FindByKeyAsync(keyVal);
         return value == null ? default : valueSerializer.Deserialize(value);
     }
 

--- a/test/MinimalKafka.RocksDB.Tests/StreamStore_Tests.cs
+++ b/test/MinimalKafka.RocksDB.Tests/StreamStore_Tests.cs
@@ -31,7 +31,7 @@ public class StreamStore_Tests
         // Test adding new key
         await streamStore.AddOrUpdate(key, value);
 
-        var val = await streamStore.FindByIdAsync(key);
+        var val = await streamStore.FindByKeyAsync(key);
 
         Assert.Equal(val,  value);
     }


### PR DESCRIPTION
The method name `FindByIdAsync` was imprecise as it retrieves values based on a generic key in a key-value store, not necessarily a unique entity identifier. Renaming it to `FindByKeyAsync` improves semantic accuracy and API clarity across the `IKafkaStore` interface and its implementations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Updates**
  * Renamed the store lookup method from `FindByIdAsync` to `FindByKeyAsync` across supported storage implementations and interfaces.
  * Updated extension-based lookups to use the new key-based method name.

* **Tests**
  * Updated storage tests to verify retrieval through `FindByKeyAsync`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->