### PR TITLE
Registers RocksDB factory as singleton

### DIFF
--- a/src/MinimalKafka.RocksDB/KafkaBuilderExtensions.cs
+++ b/src/MinimalKafka.RocksDB/KafkaBuilderExtensions.cs
@@ -18,13 +18,9 @@ public static class KafkaBuilderExtensions
     /// <returns></returns>
     public static IKafkaConfigBuilder UseRocksDB(this IKafkaConfigBuilder builder, Action<RocksDBOptions>? options = null)
     {
-        var config = new RocksDBOptions();
-        options?.Invoke(config);
-
-        Directory.CreateDirectory(config.DataPath);
-
-        builder.Services.AddSingleton<IKafkaStoreFactory>(s => new RocksDBStreamStoreFactory(s, config));
-        builder.WithStoreFactory(s => s.GetRequiredService<IKafkaStoreFactory>());
+        builder.Services.Configure(options ?? (_ => { }));
+        builder.Services.AddSingleton<RocksDBStreamStoreFactory>();
+        builder.WithStoreFactory(s => s.GetRequiredService<RocksDBStreamStoreFactory>());
         return builder;
     }
 }

--- a/src/MinimalKafka.RocksDB/KafkaBuilderExtensions.cs
+++ b/src/MinimalKafka.RocksDB/KafkaBuilderExtensions.cs
@@ -1,5 +1,5 @@
-﻿using MinimalKafka.Stream.Storage.RocksDB;
-using System.Text.Json;
+﻿using Microsoft.Extensions.DependencyInjection;
+using MinimalKafka.Stream.Storage.RocksDB;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
 namespace MinimalKafka;
@@ -23,7 +23,8 @@ public static class KafkaBuilderExtensions
 
         Directory.CreateDirectory(config.DataPath);
 
-        builder.WithStoreFactory(s => new RocksDBStreamStoreFactory(s,config));
+        builder.Services.AddSingleton<IKafkaStoreFactory>(s => new RocksDBStreamStoreFactory(s, config));
+        builder.WithStoreFactory(s => s.GetRequiredService<IKafkaStoreFactory>());
         return builder;
     }
 }

--- a/src/MinimalKafka.RocksDB/RocksDBStreamStoreFactory.cs
+++ b/src/MinimalKafka.RocksDB/RocksDBStreamStoreFactory.cs
@@ -1,27 +1,35 @@
-﻿using RocksDbSharp;
+﻿using Microsoft.Extensions.Options;
+using RocksDbSharp;
 using System.Collections.Concurrent;
 
 namespace MinimalKafka.Stream.Storage.RocksDB;
+
 internal sealed class RocksDBStreamStoreFactory : IDisposable, IKafkaStoreFactory
 {
     private readonly RocksDb _db;
     private readonly ConcurrentDictionary<string, ColumnFamilyHandle> _columnFamilies = new();
 
-    public RocksDBStreamStoreFactory(IServiceProvider serviceProvider, RocksDBOptions config)
+    public RocksDBStreamStoreFactory(IServiceProvider serviceProvider, IOptions<RocksDBOptions> config)
     {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
         ArgumentNullException.ThrowIfNull(config);
+        ArgumentException.ThrowIfNullOrWhiteSpace(config.Value.DataPath);
+
         ServiceProvider = serviceProvider;
+        Config = config;
 
         var options = new DbOptions()
             .SetCreateIfMissing(true)
             .SetCreateMissingColumnFamilies(true);
+
+        Directory.CreateDirectory(Config.Value.DataPath);
 
         // Load existing column families
         // Get existing column families or default if database is new
         string[] existingFamilies;
         try
         {
-            existingFamilies = [.. RocksDb.ListColumnFamilies(options, config.DataPath)];
+            existingFamilies = [.. RocksDb.ListColumnFamilies(options, Config.Value.DataPath)];
         }
         catch
         {
@@ -34,8 +42,8 @@ internal sealed class RocksDBStreamStoreFactory : IDisposable, IKafkaStoreFactor
         {
             cfDescriptors.Add(name, new ColumnFamilyOptions());
         }
-        
-        _db = RocksDb.Open(options, config.DataPath, cfDescriptors);
+
+        _db = RocksDb.Open(options, Config.Value.DataPath, cfDescriptors);
 
         // Store all handles
         for (int i = 0; i < existingFamilies.Length; i++)
@@ -45,13 +53,19 @@ internal sealed class RocksDBStreamStoreFactory : IDisposable, IKafkaStoreFactor
     }
 
     public IServiceProvider ServiceProvider { get; }
+    public IOptions<RocksDBOptions> Config { get; }
 
     public void Dispose()
     {
         _db?.Dispose();
     }
 
+#if NET9_0_OR_GREATER
+    private readonly Lock _lock = new();
+#else
     private readonly object _lock = new();
+#endif
+
     public IKafkaStore GetStore(string topicName)
     {
 
@@ -62,7 +76,7 @@ internal sealed class RocksDBStreamStoreFactory : IDisposable, IKafkaStoreFactor
                 // Only create if truly absent
                 return _db.CreateColumnFamily(new ColumnFamilyOptions(), key);
             });
-               
+
             return new RocksDBStreamStore(ServiceProvider, _db, cfHandle);
         }
     }


### PR DESCRIPTION
Addresses a disposable issue by registering the `RocksDBStreamStoreFactory` as a singleton in the dependency injection container. This change ensures that the factory's lifecycle is properly managed by the DI system, allowing for correct disposal of resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated RocksDB stream store configuration to use dependency injection for improved service registration and resolution.
  * Removed an unused import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->